### PR TITLE
include event details

### DIFF
--- a/src/commonMain/kotlin/co/remotectrl/ctrl/event/CtrlAggregate.kt
+++ b/src/commonMain/kotlin/co/remotectrl/ctrl/event/CtrlAggregate.kt
@@ -6,7 +6,7 @@ data class CtrlAggregate<TMutable : CtrlMutable<TMutable>>(
     val mutable: TMutable
 )
 
-data class CtrlId<TMutable>(val value: String) where TMutable : CtrlMutable<TMutable>
+data class CtrlId<TMutable>(val value: String? = null) where TMutable : CtrlMutable<TMutable>
 
 data class NotFoundCause(
     override val failMessage: String,

--- a/src/commonMain/kotlin/co/remotectrl/ctrl/event/CtrlAggregateCommandResult.kt
+++ b/src/commonMain/kotlin/co/remotectrl/ctrl/event/CtrlAggregateCommandResult.kt
@@ -1,0 +1,6 @@
+package co.remotectrl.ctrl.event
+
+data class CtrlAggregateCommandResult<TMutable : CtrlMutable<TMutable>>(
+    var aggregate: CtrlAggregate<TMutable>,
+    val command: CtrlCommand<TMutable>,
+)

--- a/src/commonMain/kotlin/co/remotectrl/ctrl/event/CtrlAggregateEvent.kt
+++ b/src/commonMain/kotlin/co/remotectrl/ctrl/event/CtrlAggregateEvent.kt
@@ -1,8 +1,19 @@
 package co.remotectrl.ctrl.event
 
-data class CtrlAggregateEvent<TMutable : CtrlMutable<TMutable>>(
+
+data class CtrlAggregateEvent<
+        TMutable : CtrlMutable<TMutable>,
+        TEvent : CtrlEvent<TMutable>,
+        >(
     val eventId: CtrlEventId<TMutable>,
     val aggregateId: CtrlId<TMutable>,
     val version: Int,
-    val mutableEvent: CtrlEvent<TMutable>
-)
+    val mutableEvent: TEvent?,
+) {
+    constructor () : this(
+        eventId = CtrlEventId("0"),
+        aggregateId = CtrlId("0"),
+        version = 0,
+        mutableEvent = null
+    )
+}

--- a/src/commonMain/kotlin/co/remotectrl/ctrl/event/CtrlAggregateEventResult.kt
+++ b/src/commonMain/kotlin/co/remotectrl/ctrl/event/CtrlAggregateEventResult.kt
@@ -1,0 +1,6 @@
+package co.remotectrl.ctrl.event
+
+data class CtrlAggregateEventResult<TMutable : CtrlMutable<TMutable>>(
+    var aggregate: CtrlAggregate<TMutable>,
+    val aggregateEvent: CtrlAggregateEvent<TMutable, CtrlEvent<TMutable>>,
+)

--- a/src/commonMain/kotlin/co/remotectrl/ctrl/event/CtrlEvent.kt
+++ b/src/commonMain/kotlin/co/remotectrl/ctrl/event/CtrlEvent.kt
@@ -4,4 +4,4 @@ interface CtrlEvent<TMutable : CtrlMutable<TMutable>> {
     fun applyChangesTo(mutable: TMutable): TMutable
 }
 
-data class CtrlEventId<TMutable>(val value: String) where TMutable : CtrlMutable<TMutable>
+data class CtrlEventId<TMutable>(val value: String? = null) where TMutable : CtrlMutable<TMutable>

--- a/src/commonMain/kotlin/co/remotectrl/ctrl/event/CtrlMutableEventResult.kt
+++ b/src/commonMain/kotlin/co/remotectrl/ctrl/event/CtrlMutableEventResult.kt
@@ -1,0 +1,6 @@
+package co.remotectrl.ctrl.event
+
+data class CtrlMutableEventResult<TMutable : CtrlMutable<TMutable>>(
+    val mutable: TMutable,
+    val event: CtrlEvent<TMutable>
+)

--- a/src/commonTest/kotlin/co/remotectrl/ctrl/event/CtrlAggregatePlayerTest.kt
+++ b/src/commonTest/kotlin/co/remotectrl/ctrl/event/CtrlAggregatePlayerTest.kt
@@ -8,218 +8,373 @@ import kotlin.test.assertTrue
 class ControlAggregatePlayerTest {
 
     @Test
-    fun given_Player_when_Command_then_create_Event() {
-        val player = getPlayer()
+    fun given_Player_when_Command_executed_then_create_Event() {
+        val player = CtrlAggregatePlayer(aggregate = getAggregate(0))
+        val played = player.execute(command = StubChangeCommand())
 
-        val played = player.eventForCommand(
-            command = StubChangeCommand()
+        assertPlayed(
+            expectedAggregateEvent = getAggregateEvent("", "1", 1, StubChangedEvent()),
+            expectedAggregate = getAggregate(1, 1),
+            played
         )
-
-        assertTrue(played is CtrlTry.Success)
-
-        val actualAggregateEvent = played.result
-
-        assertTrue(actualAggregateEvent is StubChangedEvent)
+        assertPlayer(
+            expectedAggregate = getAggregate(1, 1),
+            player
+        )
     }
+
+    private fun assertPlayer(
+        expectedAggregate: CtrlAggregate<StubMutable>,
+        player: CtrlAggregatePlayer<StubMutable>,
+    ) {
+        assertEquals(expectedAggregate.id.value, player.aggregate.id.value)
+        assertEquals(expectedAggregate.latestVersion, player.aggregate.latestVersion)
+        assertEquals(expectedAggregate.mutable.changeVal, player.aggregate.mutable.changeVal)
+    }
+
+    private fun assertPlayed(
+        expectedAggregateEvent: CtrlAggregateEvent<StubMutable, CtrlEvent<StubMutable>>,
+        expectedAggregate: CtrlAggregate<StubMutable>,
+        played: CtrlTry<CtrlAggregateEventResult<StubMutable>>,
+    ) {
+        assertTrue(played is CtrlTry.Success)
+        assertAggregateEventResult(
+            expectedAggregateEvent,
+            expectedAggregate = expectedAggregate,
+            played.result
+        )
+    }
+
+    private fun getAggregate(changeVal: Int, latestVersion: Int = 0) = CtrlAggregate(
+        id = CtrlId("1"),
+        latestVersion = latestVersion,
+        mutable = StubMutable(
+            changeVal = changeVal
+        )
+    )
 
     @Test
     fun given_Player_when_Event_played_then_apply_changes() {
-        val player = getPlayer()
+        val player = CtrlAggregatePlayer(aggregate = getAggregate(0))
 
-        val played = player.playForEvent(
-            aggregateEvent = CtrlAggregateEvent(
-                eventId = CtrlEventId("1"),
-                aggregateId = CtrlId("1"),
-                version = 1,
-                mutableEvent = StubChangedEvent()
-            )
+        val expectedAggregateEvent = getAggregateEvent("1", "1", 1, StubChangedEvent())
+        val played = player.play(
+            aggregateEvent = expectedAggregateEvent
         )
 
-        assertTrue(played is CtrlTry.Success)
-
-        assertEquals("1", played.result.id.value)
-        assertEquals(1, played.result.latestVersion)
-        assertEquals(1, played.result.mutable.changeVal)
-
-        assertEquals("1", player.aggregate.id.value)
-        assertEquals(1, player.aggregate.latestVersion)
-        assertEquals(1, player.aggregate.mutable.changeVal)
+        val expectedAggregate = getAggregate(1, 1)
+        assertPlayed(
+            expectedAggregateEvent = expectedAggregateEvent,
+            expectedAggregate = expectedAggregate,
+            played
+        )
+        assertPlayer(
+            expectedAggregate = expectedAggregate,
+            player
+        )
     }
 
     @Test
     fun given_Player_when_Event_with_different_aggregate_id_played_then_failure() {
-        val player = getPlayer()
+        val expectedAggregateEvent = getAggregateEvent("1", "2", 1, StubChangedEvent())
 
-        val played = player.playForEvent(
-            aggregateEvent = CtrlAggregateEvent(
-                eventId = CtrlEventId("1"),
-                aggregateId = CtrlId("2"), //note the aggregate id loaded in the player
-                version = 1,
-                mutableEvent = StubChangedEvent()
-            )
+        val expectedAggregate = getAggregate(0)
+        val player = CtrlAggregatePlayer(aggregate = expectedAggregate)
+        val played = player.play(
+            aggregateEvent = expectedAggregateEvent
         )
 
+
+        assertPlayedFailedData<AggregateEventInvalidAggregateIdCause<StubMutable>>(
+            expectedAggregateEvent = expectedAggregateEvent,
+            expectedAggregate = expectedAggregate,
+            played
+        )
+        assertPlayer(
+            expectedAggregate = expectedAggregate,
+            player
+        )
+    }
+
+    private inline fun <
+            reified TFailureCause : IFailureCause,
+            > assertPlayedFailedData(
+        expectedAggregateEvent: CtrlAggregateEvent<StubMutable, CtrlEvent<StubMutable>>,
+        expectedAggregate: CtrlAggregate<StubMutable>,
+        played: CtrlTry<CtrlAggregateEventResult<StubMutable>>,
+    ) {
         assertTrue(played is CtrlTry.Failure)
-        assertTrue(played.failureCause is AggregateEventInvalidAggregateIdCause<*>)
+        val actualFailureCause = played.failureCause
+        assertEquals(CtrlAggregateEventFailure::class.java.name, actualFailureCause::class.java.name)
+
+        val playerFailure: CtrlAggregateEventFailure<StubMutable> =
+            actualFailureCause as CtrlAggregateEventFailure<StubMutable>
+        assertAggregateEventResult(
+            expectedAggregateEvent = expectedAggregateEvent,
+            expectedAggregate = expectedAggregate,
+            result = playerFailure.aggregateEventResult
+        )
+        assertEquals(TFailureCause::class.java.name, playerFailure.failureCause::class.java.name)
+    }
+
+    private fun assertAggregateEventResult(
+        expectedAggregateEvent: CtrlAggregateEvent<StubMutable, CtrlEvent<StubMutable>>,
+        expectedAggregate: CtrlAggregate<StubMutable>,
+        result: CtrlAggregateEventResult<StubMutable>,
+    ) {
+        val actualAggregateEvent = result.aggregateEvent
+        assertEquals(expectedAggregateEvent.eventId.value, actualAggregateEvent.eventId.value)
+        assertEquals(expectedAggregateEvent.aggregateId.value, actualAggregateEvent.aggregateId.value)
+        assertEquals(expectedAggregateEvent.version, actualAggregateEvent.version)
         assertEquals(
-            played.failureCause.failMessage,
-            "trying to apply event with aggregate id [2] when the player is handling changes for aggregate id [1]"
-            )
+            expectedAggregateEvent.mutableEvent!!::class.java.name,
+            result.aggregateEvent.mutableEvent!!::class.java.name
+        )
+
+        val actualAggregate = result.aggregate
+        assertEquals(expectedAggregate.id.value, actualAggregate.id.value)
+        assertEquals(expectedAggregate.latestVersion, actualAggregate.latestVersion)
+        assertEquals(expectedAggregate.mutable.changeVal, actualAggregate.mutable.changeVal)
     }
 
     @Test
     fun given_Player_when_Event_with_invalid_version_played_then_failure() {
-        val player = getPlayer()
+        val expectedAggregate = getAggregate(0)
+        val player = CtrlAggregatePlayer(aggregate = expectedAggregate)
 
-        val played = player.playForEvent(
-            aggregateEvent = CtrlAggregateEvent(
-                eventId = CtrlEventId("1"),
-                aggregateId = CtrlId("1"),
-                version = 2, //not the aggregate id loaded in the player
-                mutableEvent = StubChangedEvent()
-            )
+        val expectedAggregateEvent = getAggregateEvent("1", "1", 2, StubChangedEvent())
+        val played = player.play(
+            aggregateEvent = expectedAggregateEvent,
+            checkSequentialVersion = true
         )
 
-        assertTrue(played is CtrlTry.Failure)
-        assertTrue(played.failureCause is AggregateEventInvalidVersionCause<*>)
-        assertEquals(
-            played.failureCause.failMessage,
-            "trying to apply event with version [2] when the player's current aggregate is expecting next version to be [1]"
+        assertPlayedFailedData<AggregateEventInvalidVersionCause<StubMutable>>(
+            expectedAggregateEvent = expectedAggregateEvent,
+            expectedAggregate = expectedAggregate,
+            played
+        )
+        assertPlayer(
+            expectedAggregate = expectedAggregate,
+            player
         )
     }
 
     @Test
     fun given_Player_when_Event_with_bad_data_played_then_failure() {
-        val player = getPlayer()
+        val expectedAggregate = getAggregate(0)
+        val player = CtrlAggregatePlayer(aggregate = expectedAggregate)
 
-        val played = player.playForEvent(
-            aggregateEvent = CtrlAggregateEvent(
-                eventId = CtrlEventId("1"),
-                aggregateId = CtrlId("1"),
-                version = 1,
-                mutableEvent = StubBadDivideEvent()
-            )
+        val expectedAggregateEvent = getAggregateEvent("1", "1", 1, StubBadDivideEvent())
+        val played = player.play(
+            aggregateEvent = expectedAggregateEvent
         )
 
-        assertTrue(played is CtrlTry.Failure)
-        assertTrue(played.failureCause is ApplyingBadEventCause<*>)
-        assertEquals(
-            "trying to apply bad event [StubBadDivideEvent(divideBadVal=0)] to mutable [StubMutable(changeVal=0)] but failed: [/ by zero]",
-            played.failureCause.failMessage
+        assertPlayedFailedData<ThrowableCause>(
+            expectedAggregateEvent = expectedAggregateEvent,
+            expectedAggregate = expectedAggregate,
+            played
+        )
+        assertPlayer(
+            expectedAggregate = expectedAggregate,
+            player
         )
     }
-
-    data class StubBadDivideEvent(val divideBadVal: Int = 0) : CtrlEvent<StubMutable> {
-        override fun applyChangesTo(mutable: StubMutable): StubMutable {
-            return mutable.copy(
-                changeVal = 1 / divideBadVal
-            )
-        }
-    }
-
 
     @Test
     fun given_Player_when_Events_played_then_apply_changes() {
-        val player = getPlayer()
+        val player = CtrlAggregatePlayer(aggregate = getAggregate(0))
 
-        val played = player.playForEvents(
+        val expectedEvent1 = getAggregateEvent("1", "1", 1, StubChangedEvent())
+        val expectedEvent2 = getAggregateEvent("2", "1", 2, StubBadDivideEvent())
+        val expectedEvent3 = getAggregateEvent("3", "1", 3, StubChangedEvent())
+
+        val played = player.play(
             aggregateEvents = listOf(
-                CtrlAggregateEvent(
-                    eventId = CtrlEventId("1"),
-                    aggregateId = CtrlId("1"),
-                    version = 1,
-                    mutableEvent = StubChangedEvent()
-                ),
-                CtrlAggregateEvent(
-                    eventId = CtrlEventId("2"),
-                    aggregateId = CtrlId("1"),
-                    version = 2,
-                    mutableEvent = StubChangedEvent()
-                )
+                expectedEvent1,
+                expectedEvent2,
+                expectedEvent3
             )
         )
 
-        assertTrue(played is CtrlTry.Success)
-
-        assertEquals("1", played.result.id.value)
-        assertEquals(2, played.result.latestVersion)
-        assertEquals(2, played.result.mutable.changeVal)
-
-        assertEquals("1", player.aggregate.id.value)
-        assertEquals(2, player.aggregate.latestVersion)
-        assertEquals(2, player.aggregate.mutable.changeVal)
-    }
-
-    @Test
-    fun given_Player_when_valid_Command_played_then_apply_changes() {
-        val player = getPlayer()
-
-        val played = player.playEventForCommand(
-            command = StubChangeCommand()
+        assertEquals(3, played.size)
+        val expectedAggregate1 = getAggregate(1, 1)
+        assertPlayed(
+            expectedAggregate = expectedAggregate1,
+            expectedAggregateEvent = expectedEvent1,
+            played = played[0]
+        )
+        assertPlayedFailedData<ThrowableCause>(
+            expectedAggregate = expectedAggregate1,
+            expectedAggregateEvent = expectedEvent2,
+            played = played[1]
         )
 
-        assertTrue(played is CtrlTry.Success)
-
-        assertTrue(played.result.second is StubChangedEvent)
-
-        val playedAggregate = played.result.first
-        assertEquals("1", playedAggregate.id.value)
-        assertEquals(1, playedAggregate.latestVersion)
-        assertEquals(1, playedAggregate.mutable.changeVal)
-
-        assertEquals("1", player.aggregate.id.value)
-        assertEquals(1, player.aggregate.latestVersion)
-        assertEquals(1, player.aggregate.mutable.changeVal)
+        val expectedAggregate2 = getAggregate(2, 3)
+        assertPlayed(
+            expectedAggregate = expectedAggregate2,
+            expectedAggregateEvent = expectedEvent3,
+            played = played[2]
+        )
+        assertPlayer(expectedAggregate = expectedAggregate2, player)
     }
 
     @Test
-    fun given_Player_when_valid_Commands_played_then_apply_changes() {
-        val player = getPlayer()
-
-        val played = player.playEventsForCommands(
-            commands = listOf(
-                StubChangeCommand(),
-                StubChangeCommand()
+    fun given_Player_when_Events_played_either_then_apply_changes() {
+        val player = CtrlAggregatePlayer(getAggregate(0))
+        val expectedAggregateEvent = getAggregateEvent("2", "1", 2, StubChangedEvent())
+        val played = player.playEither(
+            aggregateEvents = listOf(
+                getAggregateEvent("1", "1", 1, StubChangedEvent()),
+                expectedAggregateEvent
             )
         )
 
-        assertTrue(played is CtrlTry.Success)
+        val expectedAggregate = getAggregate(2, 2)
+        assertPlayed(
+            expectedAggregateEvent = expectedAggregateEvent,
+            expectedAggregate = expectedAggregate,
+            played
+        )
+        assertPlayer(
+            expectedAggregate = expectedAggregate,
+            player
+        )
+    }
 
-        val playedEvents = played.result.second
-        assertEquals(2, playedEvents.size)
-        assertTrue(playedEvents[0] is StubChangedEvent)
-        assertTrue(playedEvents[1] is StubChangedEvent)
+    @Test
+    fun given_Player_when_validate_invalid_Command_then_fail() {
+        val expectedAggregate = getAggregate(StubMutable.STUB_MAX_VAL)
+        val player = CtrlAggregatePlayer(aggregate = expectedAggregate)
+        val played = player.validate(StubChangeCommand())
 
-        val playedAggregate = played.result.first
-        assertEquals("1", playedAggregate.id.value)
-        assertEquals(2, playedAggregate.latestVersion)
-        assertEquals(2, playedAggregate.mutable.changeVal)
-
-        assertEquals("1", player.aggregate.id.value)
-        assertEquals(2, player.aggregate.latestVersion)
-        assertEquals(2, player.aggregate.mutable.changeVal)
+        assertValidatedFailed<InvalidCommandCause>(played)
+        assertPlayer(
+            expectedAggregate = expectedAggregate,
+            player
+        )
     }
 
     @Test
     fun given_Player_when_invalid_Command_then_fail() {
-        val player = getPlayer(StubMutable.STUB_MAX_VAL)
+        val expectedAggregate = getAggregate(StubMutable.STUB_MAX_VAL)
+        val player = CtrlAggregatePlayer(
+            aggregate = expectedAggregate
+        )
 
-        val played = player.playEventForCommand(
+        val played = player.execute(
             command = StubChangeCommand() // cannot increment higher
         )
 
-        assertTrue(played is CtrlTry.Failure)
+        assertPlayedFailed<InvalidCommandCause>(played)
 
-        assertEquals("1", player.aggregate.id.value)
-        assertEquals(0, player.aggregate.latestVersion)
-        assertEquals(StubMutable.STUB_MAX_VAL, player.aggregate.mutable.changeVal)
+        assertPlayer(
+            expectedAggregate = expectedAggregate,
+            player
+        )
     }
 
     @Test
-    fun given_Player_when_invalid_Commands_then_fail() {
-        val player = getPlayer()
+    fun given_Player_when_valid_Command_executed_with_bad_event_then_fail() {
+        val expectedAggregate = getAggregate(0, 0)
+        val player = CtrlAggregatePlayer(aggregate = expectedAggregate)
+        val played = player.execute(
+            command = StubBadDivideCommand()
+        )
 
-        val played = player.playEventsForCommands(
+        assertPlayedFailedData<ThrowableCause>(
+            expectedAggregateEvent = getAggregateEvent("", "1", 1, StubBadDivideEvent()),
+            expectedAggregate = expectedAggregate,
+            played
+        )
+        assertPlayer(
+            expectedAggregate = expectedAggregate,
+            player
+        )
+    }
+
+    @Test
+    fun given_Player_when_valid_Commands_executed_then_apply_changes() {
+        val player = CtrlAggregatePlayer(aggregate = getAggregate(0))
+        val played = player.execute(
+            commands = listOf(
+                StubChangeCommand(),
+                StubBadDivideCommand(),
+                StubChangeCommand(),
+                StubBadDivideCommand(),
+                StubChangeCommand()
+            )
+        )
+
+        assertEquals(5, played.size)
+        val expectedAggregate1 = getAggregate(1, 1)
+        assertPlayed(
+            expectedAggregateEvent = getAggregateEvent("", "1", 1, StubChangedEvent()),
+            expectedAggregate = expectedAggregate1,
+            played[0]
+        )
+        assertPlayedFailedData<ThrowableCause>(
+            expectedAggregateEvent = getAggregateEvent("", "1", 2, StubBadDivideEvent()),
+            expectedAggregate = expectedAggregate1,
+            played[1]
+        )
+
+        val expectedAggregate2 = getAggregate(2, 2)
+        assertPlayed(
+            expectedAggregateEvent = getAggregateEvent("", "1", 2, StubChangedEvent()),
+            expectedAggregate = expectedAggregate2,
+            played[2]
+        )
+        assertPlayedFailedData<ThrowableCause>(
+            expectedAggregateEvent = getAggregateEvent("", "1", 3, StubBadDivideEvent()),
+            expectedAggregate = expectedAggregate2,
+            played[3]
+        )
+        assertPlayedFailed<InvalidCommandCause>(played[4])
+        assertPlayer(
+            expectedAggregate = expectedAggregate2,
+            player
+        )
+    }
+
+    private inline fun <reified TFailureCause : IFailureCause> assertValidatedFailed(
+        played: CtrlTry<CtrlAggregateEvent<StubMutable, CtrlEvent<StubMutable>>>,
+    ) {
+        assertTrue(played is CtrlTry.Failure)
+        val actualFailureCause = played.failureCause
+        assertTrue(
+            actualFailureCause is TFailureCause,
+            "expected FailureCause to be [${TFailureCause::class.java.name}] but was [${actualFailureCause::class.java}]"
+        )
+    }
+
+    private inline fun <reified TFailureCause : IFailureCause> assertPlayedFailed(
+        played: CtrlTry<CtrlAggregateEventResult<StubMutable>>,
+    ) {
+        assertTrue(played is CtrlTry.Failure)
+        val actualFailureCause = played.failureCause
+        assertTrue(
+            actualFailureCause is TFailureCause,
+            "expected FailureCause to be [${TFailureCause::class.java.name}] but was [${actualFailureCause::class.java}]"
+        )
+    }
+
+    private fun getAggregateEvent(
+        eventIdVal: String,
+        aggregateIdVal: String,
+        version: Int,
+        mutableEvent: CtrlEvent<StubMutable>,
+    ): CtrlAggregateEvent<StubMutable, CtrlEvent<StubMutable>> =
+        CtrlAggregateEvent(
+            eventId = CtrlEventId(eventIdVal),
+            aggregateId = CtrlId(aggregateIdVal),
+            version = version,
+            mutableEvent = mutableEvent
+        )
+
+    @Test
+    fun given_Player_when_invalid_Commands_either_then_fail_without_continuing() {
+        val player = CtrlAggregatePlayer(aggregate = getAggregate(0))
+        val played = player.executeEither(
             commands = listOf(
                 StubCountIteratorCommand(),
                 StubCountIteratorCommand(),
@@ -228,22 +383,8 @@ class ControlAggregatePlayerTest {
             )
         )
 
-        assertTrue(played is CtrlTry.Failure)
-
-        assertEquals("1", player.aggregate.id.value)
-        assertEquals(0, player.aggregate.latestVersion)
-        assertEquals(0, player.aggregate.mutable.changeVal)
+        assertPlayedFailed<InvalidCommandCause>(played)
+        assertPlayer(expectedAggregate = getAggregate(2, 2), player)
     }
 
-    private fun getPlayer(changeVal: Int = 0): CtrlAggregatePlayer<StubMutable> {
-        return CtrlAggregatePlayer(
-            aggregate = CtrlAggregate(
-                id = CtrlId("1"),
-                latestVersion = 0,
-                mutable = StubMutable(
-                    changeVal = changeVal
-                )
-            ),
-        )
-    }
 }

--- a/src/commonTest/kotlin/co/remotectrl/ctrl/event/stub/StubMutable.kt
+++ b/src/commonTest/kotlin/co/remotectrl/ctrl/event/stub/StubMutable.kt
@@ -10,15 +10,21 @@ class StubChangedEvent : CtrlEvent<StubMutable> {
     )
 }
 
-var cmdAttemptCountIterator = 0
+data class StubBadDivideEvent(val divideBadVal: Int = 0) : CtrlEvent<StubMutable> {
+    override fun applyChangesTo(mutable: StubMutable): StubMutable {
+        return mutable.copy(
+            changeVal = 1 / divideBadVal
+        )
+    }
+}
 
 class StubCountIteratorCommand : StubChangeCommand() {
-    override fun validate(aggregate: StubMutable, validation: CtrlValidation) {
-        if (cmdAttemptCountIterator > StubMutable.STUB_MAX_VAL) {
+    override fun validate(mutable: StubMutable, validation: CtrlValidation) {
+        if (mutable.cmdAttemptCountIterator > StubMutable.STUB_MAX_VAL) {
             throw Exception("tried to continue parsing commands after initial failure")
         }
-        super.validate(aggregate, validation)
-        cmdAttemptCountIterator++
+        super.validate(mutable, validation)
+        mutable.cmdAttemptCountIterator++
     }
 }
 
@@ -27,16 +33,27 @@ open class StubChangeCommand : CtrlCommand<StubMutable> {
         return StubChangedEvent()
     }
 
-    override fun validate(aggregate: StubMutable, validation: CtrlValidation) {
+    override fun validate(mutable: StubMutable, validation: CtrlValidation) {
         validation.assert(
-            { aggregate.changeVal < StubMutable.STUB_MAX_VAL },
+            { mutable.changeVal < StubMutable.STUB_MAX_VAL },
             "stub value cannot be more than 3 for failure scenario"
         )
     }
 }
 
+class StubBadDivideCommand : CtrlCommand<StubMutable> {
+    override fun makeEvent(): CtrlEvent<StubMutable> {
+        return StubBadDivideEvent()
+    }
+
+    override fun validate(mutable: StubMutable, validation: CtrlValidation) {
+        //no validation
+    }
+}
+
 data class StubMutable(
-    val changeVal: Int
+    val changeVal: Int,
+    var cmdAttemptCountIterator: Int = 0
 ) : CtrlMutable<StubMutable> {
     companion object {
         const val STUB_MAX_VAL = 2


### PR DESCRIPTION
include event applied details (for aggregate and mutable) with play and execute (including list + either comprehensions)